### PR TITLE
Harden image for production use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.gitignore
+.dockerignore
+README.md
+README.hub.md
+LICENSE
+build-and-push.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-FROM openthread/otbr:latest
-# Openthread provides two images: otbr, and border-router. Both include the
-# "otbr-agent", but only otbr has the "otbr-web".
+# OpenThread Border Router with TCP-based RCP support (via socat)
+# Based on bnutzer/docker-otbr-tcp (MIT License)
+# Upstream: https://github.com/bnutzer/docker-otbr-tcp
+
+# Pin base image digest for reproducible builds
+# To update: docker pull openthread/otbr:latest && docker inspect --format='{{index .RepoDigests 0}}' openthread/otbr:latest
+FROM openthread/otbr@sha256:331fffa741e504901f7818e991952cc34ff45edb675ed6cb42a9f43a2b5d5be6
+
+LABEL org.opencontainers.image.title="OTBR TCP"
+LABEL org.opencontainers.image.description="OpenThread Border Router with remote TCP RCP support"
+LABEL org.opencontainers.image.source="https://github.com/bnutzer/docker-otbr-tcp"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.base.name="openthread/otbr"
 
 ARG S6_OVERLAY_VERSION=3.2.1.0
 
 RUN apt-get update \
 	&& apt-get upgrade -y \
-	&& apt-get install --no-install-recommends -y socat xz-utils curl ca-certificates lsof vim strace \
+	&& apt-get install --no-install-recommends -y socat xz-utils curl ca-certificates lsof \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -34,28 +44,36 @@ ENV PATH=${PATH}:/command
 COPY etc /etc
 COPY usr /usr
 
+# --- Logging ---
 ENV OTBR_LOG_LEVEL_INT="6"
 
+# --- RCP (Radio Co-Processor) via TCP/socat ---
 ENV RCP_USE_TCP="1"
 ENV RCP_PORT="6638"
-ENV SOCAT_STARTUP_GRACE_PERIOD="2"
 ENV RCP_TTY="/tmp/ttyOTBR"
 ENV RCP_BAUDRATE="460800"
+ENV SOCAT_STARTUP_GRACE_PERIOD="2"
 ENV SOCAT_SOURCE_PARAMETERS=",raw,echo=0,wait-slave,ignoreeof"
 ENV SOCAT_DESTINATION_PARAMETERS=",nodelay,keepalive,forever,interval=5"
 
+# --- OTBR REST API ---
+ENV OTBR_REST_LISTEN_ADDRESS="0.0.0.0"
+# Keep legacy typo for backwards compatibility with existing deployments
 ENV OTBR_REST_LISTEN_ADRESS="0.0.0.0"
 ENV OTBR_REST_LISTEN_PORT="8081"
+
+# --- OTBR Network ---
 ENV OTBR_THREAD_IF="wpan0"
 ENV OTBR_BACKBONE_IF="eth0"
-ENV OTBR_RCP_ADDITIONAL_ARGS=&uart-flow-control
+ENV OTBR_RCP_ADDITIONAL_ARGS="&uart-flow-control"
 
-
-ENV OTBR_BACKUP_INTERVAL="600"
-
+# --- OTBR Web UI (disabled by default) ---
 ENV OTBR_WEB_ENABLE="0"
 ENV OTBR_WEB_PORT="8080"
 ENV OTBR_WEB_LISTEN_ADDRESS="0.0.0.0"
 ENV OTBR_WEB_PATCH_REST_PORT="0"
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -sf http://localhost:${OTBR_REST_LISTEN_PORT:-8081}/node/state || exit 1
 
 ENTRYPOINT ["/init"]

--- a/etc/s6-overlay/s6-rc.d/otbr-agent/finish
+++ b/etc/s6-overlay/s6-rc.d/otbr-agent/finish
@@ -1,6 +1,2 @@
 #!/command/with-contenv /bin/bash
-set -eu
-if [[ -x /usr/local/bin/otbr-dataset.sh ]] ; then
-	exec /usr/local/bin/otbr-dataset.sh backup
-fi
 exit 0

--- a/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -8,12 +8,16 @@ if [[ $RCP_USE_TCP -gt 0 ]] ; then
 	echo "Proceeding."
 fi
 
+# Support both corrected and legacy (typo) env var name
+REST_ADDR="${OTBR_REST_LISTEN_ADDRESS:-${OTBR_REST_LISTEN_ADRESS:-0.0.0.0}}"
+
 echo "Starting otbr-agent ..."
 
-exec 
-    "/usr/sbin/otbr-agent" -I ${OTBR_THREAD_IF} -B "${OTBR_BACKBONE_IF}" \
-        --rest-listen-address "${OTBR_REST_LISTEN_ADRESS}" \
-        --rest-listen-port "${OTBR_REST_LISTEN_PORT}" \
-        -d${OTBR_LOG_LEVEL_INT} -v -s \
-        "spinel+hdlc+uart://${RCP_TTY:-/tmp/ttyOTBR}?uart-baudrate=${RCP_BAUDRATE:-460800}${OTBR_RCP_ADDITIONAL_ARGS:-}" \
-        "trel://${OTBR_BACKBONE_IF}"
+exec "/usr/sbin/otbr-agent" \
+    -I "${OTBR_THREAD_IF}" \
+    -B "${OTBR_BACKBONE_IF}" \
+    --rest-listen-address "${REST_ADDR}" \
+    --rest-listen-port "${OTBR_REST_LISTEN_PORT}" \
+    -d"${OTBR_LOG_LEVEL_INT}" -v -s \
+    "spinel+hdlc+uart://${RCP_TTY:-/tmp/ttyOTBR}?uart-baudrate=${RCP_BAUDRATE:-460800}${OTBR_RCP_ADDITIONAL_ARGS:-}" \
+    "trel://${OTBR_BACKBONE_IF}"

--- a/etc/s6-overlay/s6-rc.d/socat/run
+++ b/etc/s6-overlay/s6-rc.d/socat/run
@@ -15,6 +15,5 @@ fi
 echo "Starting socat ..."
 
 exec /usr/bin/socat -d -d \
-  -ly -lf /var/log/socat-otrcp.log \
   pty,link=${RCP_TTY}${SOCAT_SOURCE_PARAMETERS} \
   tcp:${RCP_HOST}:${RCP_PORT}${SOCAT_DESTINATION_PARAMETERS}

--- a/usr/local/bin/wait-for-otbr-agent
+++ b/usr/local/bin/wait-for-otbr-agent
@@ -2,12 +2,15 @@
 
 set -eu
 
-for i in $(seq 1 180); do
+timeout=180
+elapsed=0
+while [[ $elapsed -lt $timeout ]]; do
 	if wrap-ot-ctl state >/dev/null 2>&1; then
 		echo "otbr-agent is ready."
 		exit 0
 	fi
 	sleep 1
+	elapsed=$((elapsed + 1))
 done
-echo "otbr-agent-ready: ot-ctl never responded, startup failed." >&2
+echo "otbr-agent-ready: ot-ctl never responded after ${timeout}s, startup failed." >&2
 exit 1

--- a/usr/local/bin/wait-for-socat
+++ b/usr/local/bin/wait-for-socat
@@ -6,11 +6,14 @@ if [[ "$RCP_USE_TCP" == "0" ]] ; then
 	exit 0
 fi
 
-for i in $(seq 1 120); do
+timeout=120
+elapsed=0
+while [[ $elapsed -lt $timeout ]]; do
   if [[ -e "$RCP_TTY" ]] && [[ -r "$RCP_TTY" ]]; then
     exit 0
   fi
   sleep 1
+  elapsed=$((elapsed + 1))
 done
-echo "socat-ready: TTY $RCP_TTY NOT ready" >&2
+echo "socat-ready: TTY $RCP_TTY NOT ready after ${timeout}s" >&2
 exit 1


### PR DESCRIPTION
## Summary

A collection of hardening and best-practice improvements for the Docker image, focused on production readiness and maintainability.

### Changes

**Build reproducibility & metadata:**
- Pin base image to digest (`openthread/otbr@sha256:331fff...`) instead of `:latest` for reproducible builds
- Add OCI image labels (`title`, `description`, `source`, `licenses`, `base.name`)
- Add `.dockerignore` to reduce build context size

**Image size & security:**
- Remove debug packages (`vim`, `strace`) from production image (~30MB savings)

**Reliability:**
- Add Docker `HEALTHCHECK` that queries the REST API (`/node/state`)
- Fix fragile `exec` continuation in `otbr-agent/run` (empty line between `exec` and command)
- Quote `OTBR_RCP_ADDITIONAL_ARGS` properly (`"&uart-flow-control"`)

**Bug fixes:**
- Fix `OTBR_REST_LISTEN_ADDRESS` typo — add correctly spelled env var while keeping legacy `OTBR_REST_LISTEN_ADRESS` as fallback for backwards compatibility
- Remove dead code in `otbr-agent/finish` (references deleted `otbr-dataset.sh` backup script)
- Remove unused `OTBR_BACKUP_INTERVAL` env var

**Logging:**
- Log socat output to stdout (Docker-managed) instead of unbounded `/var/log/socat-otrcp.log` file

**Code quality:**
- Replace `for i in $(seq ...)` with explicit counter in polling loops (unused `$i`, clearer timeout reporting)
- Group and document ENV variables by function in Dockerfile

## Test plan

- [x] Built and tested on amd64 with SLZB-MR5U (EFR32MG24) as remote TCP RCP
- [x] Verified REST API responds on custom port (`--rest-listen-port 8087`)
- [x] Verified HEALTHCHECK reports `healthy`
- [x] Verified OCI labels present via `docker inspect`
- [x] Verified socat logs appear in `docker logs` (no file growth)
- [x] Verified Thread network forms and reaches `leader` state
- [x] Verified backwards compatibility: `OTBR_REST_LISTEN_ADRESS` (typo) still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)